### PR TITLE
fix: Prevent error when mode-line-position is nil

### DIFF
--- a/parrot.el
+++ b/parrot.el
@@ -129,8 +129,10 @@ using `parrot-create' directly whenever `parrot-mode' is active."
     (progn
       (unless parrot--old-cdr-mode-line-position
         (setq parrot--old-cdr-mode-line-position (cdr mode-line-position))
-        (setcdr mode-line-position (cons '(:eval (list (parrot--create)))
-                                         (cdr parrot--old-cdr-mode-line-position))))
+        (when mode-line-position
+          (setcdr mode-line-position
+                  (cons '(:eval (list (parrot--create)))
+                        (cdr parrot--old-cdr-mode-line-position)))))
       (setf parrot--visible t)
       (force-mode-line-update))))
 
@@ -138,7 +140,8 @@ using `parrot-create' directly whenever `parrot-mode' is active."
   "Remove parrot from modeline."
   (when parrot--visible
     (progn
-      (setcdr mode-line-position parrot--old-cdr-mode-line-position)
+      (when mode-line-position
+        (setcdr mode-line-position parrot--old-cdr-mode-line-position))
       (setf parrot--old-cdr-mode-line-position nil)
       (setf parrot--visible nil)
       (force-mode-line-update))))


### PR DESCRIPTION
This PR is to fix an error when `mode-line-position` is nil:
```elisp
Debugger entered--Lisp error: (wrong-type-argument consp nil)
setcdr(nil ((:eval (list (parrot--create)))))
(if parrot--old-cdr-mode-line-position nil (setq parrot--old-cdr-mode-line-position (cdr mode-line-position)) (setcdr mode-line-position (cons '(:eval (list (parrot--create))) (cdr parrot--old-cdr-mode-line-position))))
(progn (if parrot--old-cdr-mode-line-position nil (setq parrot--old-cdr-mode-line-position (cdr mode-line-position)) (setcdr mode-line-position (cons '(:eval (list (parrot--create))) (cdr parrot--old-cdr-mode-line-position)))) (setq parrot--visible t) (force-mode-line-update))
(if parrot--visible nil (progn (if parrot--old-cdr-mode-line-position nil (setq parrot--old-cdr-mode-line-position (cdr mode-line-position)) (setcdr mode-line-position (cons '(:eval (list ...)) (cdr parrot--old-cdr-mode-line-position)))) (setq parrot--visible t) (force-mode-line-update)))
parrot--show-parrot()
(let* ((user (called-interactively-p 'interactive)) (animate (or user (not (eq parrot-animate 'no-animation)) force-animation))) (if (not (and (boundp 'parrot-mode) parrot-mode)) (progn (parrot-mode))) (parrot--show-parrot) (if (eq parrot--rotations -1) nil (setq parrot--rotations (if persist -1 0))) (if animate (progn (if (not parrot--animation-timer) (progn (setq parrot--animation-timer (run-at-time nil parrot-animation-frame-interval #'parrot--switch-anim-frame)))))))
parrot-start-animation()
funcall-interactively(parrot-start-animation)
command-execute(parrot-start-animation record)
execute-extended-command(nil "parrot-start-animation" #("parrot st" 0 9 (ws-butler-chg chg)))
funcall-interactively(execute-extended-command nil "parrot-start-animation" #("parrot st" 0 9 (ws-butler-chg chg)))
command-execute(execute-extended-command)
```