### PR TITLE
Parrot fix docs and magit require

### DIFF
--- a/parrot-progress.el
+++ b/parrot-progress.el
@@ -46,7 +46,7 @@ Use `parrot-progress-finished' to stop."
 PROCESS the git process Replace sentinel for PROCESS, usually
 `magit-process-sentinel' and modify it to call our own sentinel
 just until this PROCESS is finished."
-  (if-let ((sentinel (process-sentinel process)))
+  (if-let* ((sentinel (process-sentinel process)))
       (set-process-sentinel process
                             (lambda (&rest args)
                               (apply sentinel args)

--- a/parrot-rotate.el
+++ b/parrot-rotate.el
@@ -103,7 +103,7 @@ It has no effect if ‘parrot-rotate-hunt-for-words’ is nil."
 
 (defcustom parrot-rotate-start-bound-regexp "[[:space:]]"
   "Regex to search backward for text rotation start point.
-This should be the point before the start character that will be NOT considered
+This should be the point before the start character that will NOT be considered
 part of the text rotation scope.  By default, it is set to [[:space:]], so
 parrot will search a whitespace-delimited word for potential rotations.  You can
 change it to [\]\[[:space:](){}<>] to treat braces/brackets as boundaries."
@@ -112,7 +112,7 @@ change it to [\]\[[:space:](){}<>] to treat braces/brackets as boundaries."
 
 (defcustom parrot-rotate-end-bound-regexp "[[:space:]]"
   "Regex to search forward for text rotation end point.
-This should be the point after the end character that will be NOT considered
+This should be the point after the end character that will NOT be considered
 part of the text rotation scope.  By default, it is set to [[:space:]], so
 parrot will search a whitespace-delimited word for potential rotations.  You can
 change it to [\]\[[:space:](){}<>] to treat braces/brackets as boundaries."

--- a/parrot.el
+++ b/parrot.el
@@ -43,9 +43,9 @@
 
 ;;; Code:
 
-(require 'magit)
 (require 'parrot-rotate)
 (require 'parrot-progress)
+(declare-function magit-run-git-async "magit-process" t)
 
 (defconst parrot-directory (file-name-directory (or load-file-name buffer-file-name)))
 (defconst parrot-modeline-help-string "mouse-1: Animate!")
@@ -429,7 +429,7 @@ You can customize this minor mode, see `customize-group' `parrot'."
         (if parrot-animate-on-load
             (parrot-start-animation nil t)
           (if (memq parrot-animate '(animate no-animation))
-            (parrot--show-parrot)))
+              (parrot--show-parrot)))
         (parrot--maybe-add-todo-hook)
         (parrot--maybe-advise-magit-push))
     (progn

--- a/parrot.el
+++ b/parrot.el
@@ -286,7 +286,7 @@ Possible values:
 animating or not.
 
 - The symbol `no-animation' to show the parrot but never animate
-it.  The symbol `hide-static' to only show the parrot when not
+it.  The symbol `hide-static' to only show the parrot when
 animating.
 
 - nil will revert to the legacy `parrot-animate-parrot' no

--- a/parrot.el
+++ b/parrot.el
@@ -390,7 +390,7 @@ When called interactively, this function does not respect
 (defun parrot-stop-animation ()
   "Stop the parrot animation.
 If a persistent animation is being broken, animation will
-continue for `parrot-num-roatiations'"
+continue for `parrot-num-rotations'"
   (interactive)
   (if (eq parrot--rotations -1)
       (setq parrot--rotations 0)

--- a/parrot.el
+++ b/parrot.el
@@ -267,7 +267,7 @@ See `parrot-party-on-org-todo-states'."
          (parrot--refresh t)))
 
 (defcustom parrot-num-rotations 3
-  "How many times party parrot will rotate."
+  "How many times the parrot will rotate."
   :group 'parrot
   :type 'integer
   :set (lambda (sym val)
@@ -296,7 +296,7 @@ animating.
          ;; map legacy nil value to 'no-animation
          ;; map legacy t value to 'animate
          (let* ((val (if (eq val nil) 'no-animation val))
-                (val (if (eq val t) 'animation val)))
+                (val (if (eq val t) 'animate val)))
            (set-default sym val)
            (parrot--refresh))))
 

--- a/parrot.el
+++ b/parrot.el
@@ -107,13 +107,13 @@ For example, an animation with a total of ten frames would have a
 (defun parrot--refresh (&optional maybe-static)
   "Show the results of updated options.
 
-MAYBE-STATIC is appropriate for changes that do not affect
-animation and cannot be better demonstrated with animation.  This
-is also affected by `parrot-animate'.  If the parrot only shows
-during animation, then it will animate to show the update.
+MAYBE-STATIC is appropriate for changes that do not affect animation and
+cannot be better demonstrated with animation. This is also affected by
+`parrot-animate'. If the parrot only shows during animation, then it
+will animate to show the update.
 
-This refresh will enable the mode if necessary to provide user
-feedback, which could also animate depending on settings."
+This refresh will enable the mode if necessary to provide user feedback,
+which could also animate depending on settings."
   (when (featurep 'parrot)
     (if (not parrot-mode)
         (parrot-mode 1)
@@ -125,9 +125,9 @@ feedback, which could also animate depending on settings."
 
 (defun parrot--show-parrot ()
   "Add parrot to the modeline.
-If you are a `doom-modeline' user, see
-`doom-modeline-segment--parrot'.  Doom performs some overrides,
-using `parrot-create' directly whenever `parrot-mode' is active."
+If you are a `doom-modeline' user, see `doom-modeline-segment--parrot'.
+Doom performs some overrides, using `parrot-create' directly whenever
+`parrot-mode' is active."
   (unless parrot--visible
     (progn
       (unless parrot--old-cdr-mode-line-position
@@ -282,15 +282,14 @@ See `parrot-party-on-org-todo-states'."
   "Animation and show/hide preference.
 Possible values:
 
-- non-nil or the symbol `animate' to always show the parrot,
-animating or not.
+- non-nil or the symbol `animate' to always show the parrot, animating
+or not.
 
-- The symbol `no-animation' to show the parrot but never animate
-it.  The symbol `hide-static' to only show the parrot when
-animating.
+- The symbol `no-animation' to show the parrot but never animate it. The
+symbol `hide-static' to only show the parrot when animating.
 
-- nil will revert to the legacy `parrot-animate-parrot' no
-  animation behavior (equivalent to `no-animation')."
+- nil will revert to the legacy `parrot-animate-parrot' no animation
+  behavior (equivalent to `no-animation')."
   :group 'parrot
   :type '(choice (const :tag "Animate and always show" animate)
                  (const :tag "Show but never animate" no-animation)
@@ -337,8 +336,8 @@ Also see `parrot-set-parrot-type'."
 
 (defcustom parrot-party-on-org-todo-states '("DONE")
   "If non-nil, these org todo states will trigger a party.
-This will happen whenever the `org-after-todo-state-change' hook
-is called.  See `org-todo-keywords'."
+This will happen whenever the `org-after-todo-state-change' hook is
+called. See `org-todo-keywords'."
   :group 'parrot
   :type '(repeat string)
   :set (lambda (sym val)
@@ -392,8 +391,8 @@ When called interactively, this function does not respect
 ;;;###autoload
 (defun parrot-stop-animation ()
   "Stop the parrot animation.
-If a persistent animation is being broken, animation will
-continue for `parrot-num-rotations'"
+If a persistent animation is being broken, animation will continue for
+`parrot-num-rotations'"
   (interactive)
   (if (eq parrot--rotations -1)
       (setq parrot--rotations 0)
@@ -406,7 +405,8 @@ continue for `parrot-num-rotations'"
 
 (defun parrot-set-parrot-type (parrot &optional silent)
   "Set the desired PARROT type in the mode line.
-When SILENT is non-nil, do not show the parrot even if settings would enable it."
+When SILENT is non-nil, do not show the parrot even if settings would
+enable it."
   (interactive
    (list
     (completing-read "Select parrot: "

--- a/parrot.el
+++ b/parrot.el
@@ -47,6 +47,9 @@
 (require 'parrot-progress)
 (declare-function magit-run-git-async "magit-process" t)
 
+(eval-when-compile
+  (require 'magit nil t))
+
 (defconst parrot-directory (file-name-directory (or load-file-name buffer-file-name)))
 (defconst parrot-modeline-help-string "mouse-1: Animate!")
 
@@ -428,8 +431,8 @@ You can customize this minor mode, see `customize-group' `parrot'."
         (parrot--load-frames parrot-type)
         (if parrot-animate-on-load
             (parrot-start-animation nil t)
-          (if (memq parrot-animate '(animate no-animation))
-              (parrot--show-parrot)))
+          (when (memq parrot-animate '(animate no-animation))
+            (parrot--show-parrot)))
         (parrot--maybe-add-todo-hook)
         (parrot--maybe-advise-magit-push))
     (progn

--- a/parrot.el
+++ b/parrot.el
@@ -336,7 +336,7 @@ Also see `parrot-set-parrot-type'."
            (parrot--maybe-advise-magit-push))))
 
 (defcustom parrot-party-on-org-todo-states '("DONE")
-  "If non-nil, these org todo states will trigger party.
+  "If non-nil, these org todo states will trigger a party.
 This will happen whenever the `org-after-todo-state-change' hook
 is called.  See `org-todo-keywords'."
   :group 'parrot
@@ -406,7 +406,7 @@ continue for `parrot-num-rotations'"
 
 (defun parrot-set-parrot-type (parrot &optional silent)
   "Set the desired PARROT type in the mode line.
-SILENT will not show the parrot even if settings enable it."
+When SILENT is non-nil, do not show the parrot even if settings would enable it."
   (interactive
    (list
     (completing-read "Select parrot: "

--- a/parrot.el
+++ b/parrot.el
@@ -287,7 +287,7 @@ it.  The symbol `hide-static' to only show the parrot when not
 animating.
 
 - nil will revert to the legacy `parrot-animate-parrot' no
-  animation behavior, the same as `'no-animation'."
+  animation behavior (equivalent to `no-animation')."
   :group 'parrot
   :type '(choice (const :tag "Animate and always show" animate)
                  (const :tag "Show but never animate" no-animation)


### PR DESCRIPTION
Fixing some parts of the doc that are confusing like how `parrot-animate` documents `hide-static` as only showing the parrot when it's not animating (even though that incorrect).

While I was add it, I decided to make it so we don't load Magit unnecessarily either.